### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "http://github.com/indexzero/winston-couchdb"
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "couchdb"],
+  "license": "MIT",
   "dependencies": {
     "cradle": "0.6.x",
     "cycle": "1.0.x"


### PR DESCRIPTION
This makes winston-couchdb compatible with license tools.
