### PR TITLE
Disable the Cradle write cache in order to fix a memory leak

### DIFF
--- a/lib/winston-couchdb.js
+++ b/lib/winston-couchdb.js
@@ -162,14 +162,15 @@ Couchdb.prototype._ensureView = function (callback) {
 
 //
 // ### function _ensureClient ()
-// Ensure the existence of a crade client.
+// Ensure the existence of a Cradle client.
 //
 Couchdb.prototype._ensureClient = function () {
   if (this._client) return this._client;
   var Cradle = require('cradle').Connection;
   this._client = new Cradle(this.host, this.port, {
     secure: this.secure,
-    auth: this.auth
+    auth: this.auth,
+    cache: false
   }).database(this.db);
   this._ensureView();
   return this._client;


### PR DESCRIPTION
If you log to CouchDB on a regular basis, the memory usage grows steadily. Apparently this has to do with the Cradle write cache (see e.g. http://louis.chefbe.net/wp/?p=30). This PR disables the Cradle write cache, making the mem usage look much better at least here.
